### PR TITLE
CTFのスモークテストに30分のタイムアウトを追加

### DIFF
--- a/.github/workflows/smoke-ctf.yml
+++ b/.github/workflows/smoke-ctf.yml
@@ -17,6 +17,7 @@ jobs:
   smoke-test:
     name: Smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       id: checkout


### PR DESCRIPTION
close #3 